### PR TITLE
application.html.erb and _setup.scss patch

### DIFF
--- a/app/assets/stylesheets/config/_setup.scss
+++ b/app/assets/stylesheets/config/_setup.scss
@@ -58,7 +58,7 @@ ul {
   margin: 0 auto;
   max-width: 80%;
   min-width: none;
-  width: 1200;
+  width: 1200px;
 }
 
 .text-red {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,13 @@
   </head>
 
   <body>
-    <%= render "shared/navbar" %>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <%= render "devise/shared/flashes" %>
-    <%= yield %>
+    <header>
+      <%= render "shared/navbar" %>
+    </header>
+
+    <main>
+      <%= render "devise/shared/flashes" %>
+      <%= yield %>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
The "px" was missing from the _setup.scss `.container-1200` width.

There was also a duplication of the same elements in the application.html.erb
The shared/flashes partial that is rendered is doing the same thing as the notice and alert. I had removed it but it must have been added again during one of the merge. I removed them again and added `header` and `main` element tags around some content while I was at it.