### PR TITLE
Generated stimulus controller for price and blocked date fields

### DIFF
--- a/app/assets/stylesheets/arts/_show.scss
+++ b/app/assets/stylesheets/arts/_show.scss
@@ -51,6 +51,26 @@
     grid-template-columns: 1fr 420px;
   }
 
+  .price-summary {
+    p {
+      display: flex;
+      justify-content: space-between;
+      margin: 10px 0;
+    }
+
+    span {
+      color: $gold;
+    }
+
+    #total {
+      border-top: $border-default;
+      font-size: 22px;
+      font-weight: 500;
+      margin: 0;
+      padding-top: 10px;
+    }
+  }
+
   .user {
     border-bottom: $border-default;
     display: flex;

--- a/app/javascript/controllers/booking_form_price_controller.js
+++ b/app/javascript/controllers/booking_form_price_controller.js
@@ -2,24 +2,18 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="booking-form-price"
 export default class extends Controller {
-  connect() {
-    console.log("h");
-  }
-
   static targets = ["startDate", "endDate", "price", "field", "days"]
 
   enabledEndDateField() {
+    this.endDateTarget.value = ""
     this.endDateTarget.min = new Date(new Date(this.startDateTarget.value).valueOf() + 86400000).toISOString().split('T')[0]
-    console.log(new Date(new Date(this.startDateTarget.value).valueOf() + 86400000).toISOString().split('T')[0]);
     this.endDateTarget.disabled = false
-    console.log(this.endDateTarget);
   }
 
   updatePrice() {
     const days = Math.floor(((new Date(this.endDateTarget.value)) - (new Date(this.startDateTarget.value))) / 86400000)
     const price = (+this.priceTarget.value).toFixed(2)
 
-    console.log(days);
     this.daysTarget.innerText = ""
     this.fieldTarget.innerText = ""
 

--- a/app/javascript/controllers/booking_form_price_controller.js
+++ b/app/javascript/controllers/booking_form_price_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="booking-form-price"
+export default class extends Controller {
+  connect() {
+    console.log("h");
+  }
+
+  static targets = ["startDate", "endDate", "price", "field", "days"]
+
+  enabledEndDateField() {
+    this.endDateTarget.min = new Date(new Date(this.startDateTarget.value).valueOf() + 86400000).toISOString().split('T')[0]
+    console.log(new Date(new Date(this.startDateTarget.value).valueOf() + 86400000).toISOString().split('T')[0]);
+    this.endDateTarget.disabled = false
+    console.log(this.endDateTarget);
+  }
+
+  updatePrice() {
+    const days = Math.floor(((new Date(this.endDateTarget.value)) - (new Date(this.startDateTarget.value))) / 86400000)
+    const price = (+this.priceTarget.value).toFixed(2)
+
+    console.log(days);
+    this.daysTarget.innerText = ""
+    this.fieldTarget.innerText = ""
+
+    if (days * price > 0) {
+      this.daysTarget.innerText = days
+      this.fieldTarget.innerText = `${(days * price).toFixed(2)}€`
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,8 +7,8 @@ import { application } from "./application"
 import AosController from "./aos_controller"
 application.register("aos", AosController)
 
-import Carousel from 'stimulus-carousel'
-application.register('carousel', Carousel)
+import BookingFormPriceController from "./booking_form_price_controller"
+application.register("booking-form-price", BookingFormPriceController)
 
 import DropdownMenuController from "./dropdown_menu_controller"
 application.register("dropdown-menu", DropdownMenuController)

--- a/app/views/arts/show.html.erb
+++ b/app/views/arts/show.html.erb
@@ -63,7 +63,7 @@
         <div class="form-group">
           <div class="form-field">
             <%= f.label "From" %>
-            <%= f.date_field :start_date, min: Date.today, onkeydown: "return false", data: { "booking-form-price-target": "startDate", action: "change->booking-form-price#enabledEndDateField" } %>
+            <%= f.date_field :start_date, min: Date.today, onkeydown: "return false", data: { "booking-form-price-target": "startDate", action: "change->booking-form-price#enabledEndDateField change->booking-form-price#updatePrice" } %>
           </div>
 
           <div class="form-field">

--- a/app/views/arts/show.html.erb
+++ b/app/views/arts/show.html.erb
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <div class="booking">
+    <div class="booking" data-controller="booking-form-price">
       <%= form_with model: [@art, @booking] do |f| %>
         <h3>Book now</h3>
 
@@ -52,6 +52,8 @@
           </div>
         <% end %>
 
+        <%= f.hidden_field :price, value: @art.price, data: { "booking-form-price-target": "price" }%>
+
 
         <div class="form-field">
           <%= f.label :address %>
@@ -61,16 +63,22 @@
         <div class="form-group">
           <div class="form-field">
             <%= f.label "From" %>
-            <%= f.date_field :start_date %>
+            <%= f.date_field :start_date, min: Date.today, onkeydown: "return false", data: { "booking-form-price-target": "startDate", action: "change->booking-form-price#enabledEndDateField" } %>
           </div>
 
           <div class="form-field">
             <%= f.label "To" %>
-            <%= f.date_field :end_date %>
+            <%= f.date_field :end_date, disabled: true, onkeydown: "return false", data: { "booking-form-price-target": "endDate", action: "change->booking-form-price#updatePrice" } %>
           </div>
         </div>
 
         <%= f.submit "Confirm", class: "btn-default btn-gold" %>
+
+        <div class="price-summary">
+          <p>Price per day:<span><%= @art.price.round(2) %>€/day</span></p>
+          <p>Number of days:<span data-booking-form-price-target="days"></span></p>
+          <p id="total">Total:<span data-booking-form-price-target="field">€</span></p>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
The date fields now have minimum values to avoid someone using a date earlier than today.
The second date field minimum value is the day after the selected starting date.
The fields can't be filled with a keyboard input, it has to be selected from the table to avoid bugs.
The end date field is disabled until a start date has been selected
![image](https://user-images.githubusercontent.com/75388869/221351795-911b1352-3181-44e2-859a-65ddcae653bc.png)


Then once both date have been selected the Stimulus controller fills the text at the bottom to input the price dynamically
![image](https://user-images.githubusercontent.com/75388869/221351824-25fa98cb-0514-447c-a072-1aed6b95b920.png)
